### PR TITLE
feat(templates): move `withDashboard` to `withProviders.tsx`

### DIFF
--- a/custom-products-catalog/template/src/dashboard/pages/page.tsx
+++ b/custom-products-catalog/template/src/dashboard/pages/page.tsx
@@ -15,7 +15,6 @@ import {
 } from '@wix/design-system';
 import '@wix/design-system/styles.global.css';
 import * as Icons from '@wix/wix-ui-icons-common';
-import { withDashboard } from '@wix/dashboard-react';
 import type { products } from '@wix/stores';
 import { withProviders } from '../withProviders';
 import { useDeleteProducts, useProductsQuery } from '../hooks/stores';
@@ -159,4 +158,4 @@ function Products() {
   );
 }
 
-export default withDashboard(withProviders(Products));
+export default withProviders(Products);

--- a/custom-products-catalog/template/src/dashboard/withProviders.tsx
+++ b/custom-products-catalog/template/src/dashboard/withProviders.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import {
+  QueryClientProvider,
+  QueryClient,
+} from '@tanstack/react-query';
 import { WixDesignSystemProvider } from '@wix/design-system';
-
-const queryClient = new QueryClient();
+import { withDashboard } from '@wix/dashboard-react';
 
 export function withProviders<P extends {} = {}>(Component: React.FC<P>) {
-  return function DashboardProviders(props: P) {
+  return withDashboard(function DashboardProviders(props: P) {
+    const queryClient = new QueryClient();
     return (
       <WixDesignSystemProvider>
         <QueryClientProvider client={queryClient}>
@@ -13,5 +16,5 @@ export function withProviders<P extends {} = {}>(Component: React.FC<P>) {
         </QueryClientProvider>
       </WixDesignSystemProvider>
     );
-  };
+  });
 }

--- a/mixpanel-analytics/template/src/dashboard/pages/page.tsx
+++ b/mixpanel-analytics/template/src/dashboard/pages/page.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Page, Card, Box, Text, TextButton } from '@wix/design-system';
 import '@wix/design-system/styles.global.css';
-import { withDashboard } from '@wix/dashboard-react';
 import { withProviders } from '../withProviders';
 import ProjectToken from '../components/ProjectToken.js';
 
@@ -37,4 +36,4 @@ function MixpanelAnalytics() {
   );
 }
 
-export default withDashboard(withProviders(MixpanelAnalytics));
+export default withProviders(MixpanelAnalytics);

--- a/site-popup/template/src/components/close-button.tsx
+++ b/site-popup/template/src/components/close-button.tsx
@@ -19,9 +19,9 @@ export const CloseButton: FC<Props> = ({ onClick }) => {
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            fill-rule="evenodd"
+            fillRule="evenodd"
             d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-            clip-rule="evenodd"
+            clipRule="evenodd"
           ></path>
         </svg>
       </button>

--- a/site-popup/template/src/dashboard/pages/page.tsx
+++ b/site-popup/template/src/dashboard/pages/page.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Cell, Layout, Loader, Page } from '@wix/design-system';
-import { withDashboard } from '@wix/dashboard-react';
 import '@wix/design-system/styles.global.css';
 import { withProviders } from '../withProviders';
 import { SitePopupSettings } from '../../components/site-popup-settings.js';
@@ -73,4 +72,4 @@ function SitePopup() {
   );
 }
 
-export default withDashboard(withProviders(SitePopup));
+export default withProviders(SitePopup);


### PR DESCRIPTION
Changes:
1. Align all templates to wrap with `withDashboard` inside `withProviders()`
2. Small fix to SVG