### PR TITLE
chore: rm `serve` command from templates

### DIFF
--- a/chart-widget/template/package.json.ejs
+++ b/chart-widget/template/package.json.ejs
@@ -25,7 +25,6 @@ to: package.json
     "release": "wix app release",
     "dev": "wix app dev",
     "preview": "wix app preview",
-    "serve": "wix app serve",
     "logs": "wix app logs",
     "generate": "wix app generate",
     "typecheck": "tsc --noEmit"

--- a/custom-products-catalog/template/package.json.ejs
+++ b/custom-products-catalog/template/package.json.ejs
@@ -27,7 +27,6 @@ to: package.json
     "release": "wix app release",
     "dev": "wix app dev",
     "preview": "wix app preview",
-    "serve": "wix app serve",
     "logs": "wix app logs",
     "generate": "wix app generate",
     "typecheck": "tsc --noEmit"

--- a/inventory-countdown/template/package.json.ejs
+++ b/inventory-countdown/template/package.json.ejs
@@ -28,7 +28,6 @@ to: package.json
     "release": "wix app release",
     "dev": "wix app dev",
     "preview": "wix app preview",
-    "serve": "wix app serve",
     "generate": "wix app generate",
     "logs": "wix app logs",
     "typecheck": "tsc --noEmit"

--- a/mixpanel-analytics/template/package.json.ejs
+++ b/mixpanel-analytics/template/package.json.ejs
@@ -26,7 +26,6 @@ to: package.json
     "release": "wix app release",
     "dev": "wix app dev",
     "preview": "wix app preview",
-    "serve": "wix app serve",
     "logs": "wix app logs",
     "generate": "wix app generate",
     "typecheck": "tsc --noEmit"

--- a/shipping-rates/template/package.json.ejs
+++ b/shipping-rates/template/package.json.ejs
@@ -27,7 +27,6 @@ to: package.json
     "release": "wix app release",
     "dev": "wix app dev",
     "preview": "wix app preview",
-    "serve": "wix app serve",
     "logs": "wix app logs",
     "generate": "wix app generate",
     "typecheck": "tsc --noEmit"

--- a/site-popup/template/package.json.ejs
+++ b/site-popup/template/package.json.ejs
@@ -29,7 +29,6 @@ to: package.json
     "release": "wix app release",
     "dev": "wix app dev",
     "preview": "wix app preview",
-    "serve": "wix app serve",
     "logs": "wix app logs",
     "generate": "wix app generate",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
The `wix app serve` command is deprecated in favor of `wix app preview`.