### PR TITLE
chore(@wix/dashboard): add peer dependency

### DIFF
--- a/custom-products-catalog/template/package.json.ejs
+++ b/custom-products-catalog/template/package.json.ejs
@@ -5,6 +5,7 @@ to: package.json
   "name": "<%= packageName %>",
   "version": "1.0.0",
   "dependencies": {
+    "@wix/dashboard": "^1.3.43",
     "@wix/design-system": "^1.111.0",
     "@wix/essentials": "^0.1.4",
     "@wix/patterns": "^1.3.0",


### PR DESCRIPTION
Though marked as optional, but still required by `@wix/patterns`