### PR TITLE
feat: migrate app templates to @wix/astro-wix-hosting-adapter

### DIFF
--- a/blank/template/astro.config.mjs
+++ b/blank/template/astro.config.mjs
@@ -2,11 +2,11 @@
 import { defineConfig } from 'astro/config';
 import wix from '@wix/astro';
 import react from "@astrojs/react";
-import cloudflare from "@astrojs/cloudflare";
+import wixHostingAdapter from "@wix/astro-wix-hosting-adapter";
 
 export default defineConfig({
   output: "server",
-  adapter: cloudflare(),
+  adapter: wixHostingAdapter(),
   integrations: [wix(), react()],
   image: { domains: ["static.wixstatic.com"] },
   devToolbar: { enabled: false },

--- a/blank/template/package.json.ejs
+++ b/blank/template/package.json.ejs
@@ -17,7 +17,7 @@ to: package.json
     "generate": "wix generate"
   },
   "dependencies": {
-    "@wix/astro": "^2.13.0",
+    "@wix/astro": "^2.39.0",
     "@wix/dashboard": "^1.3.36",
     "@wix/design-system": "^1.0.0",
     "@wix/essentials": "^0.1.23",
@@ -25,10 +25,10 @@ to: package.json
     "typescript": "^5.8.3"
   },
   "devDependencies": {
-    "@astrojs/cloudflare": "^12.5.3",
     "@astrojs/react": "^4.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
     "@wix/cli": "^1.1.135",
     "@wix/sdk-types": "^1.0.0",
     "react": "^18.3.1",

--- a/chart-widget/template/astro.config.mjs
+++ b/chart-widget/template/astro.config.mjs
@@ -2,11 +2,11 @@
 import { defineConfig } from 'astro/config';
 import wix from '@wix/astro';
 import react from "@astrojs/react";
-import cloudflare from "@astrojs/cloudflare";
+import wixHostingAdapter from "@wix/astro-wix-hosting-adapter";
 
 export default defineConfig({
   output: "server",
-  adapter: cloudflare(),
+  adapter: wixHostingAdapter(),
   integrations: [wix(), react()],
   image: { domains: ["static.wixstatic.com"] },
   devToolbar: { enabled: false },

--- a/chart-widget/template/package.json.ejs
+++ b/chart-widget/template/package.json.ejs
@@ -17,7 +17,7 @@ to: package.json
     "generate": "wix generate"
   },
   "dependencies": {
-    "@wix/astro": "^2.13.0",
+    "@wix/astro": "^2.39.0",
     "@wix/design-system": "^1.0.0",
     "@wix/editor": "^1.0.0",
     "@wix/wix-ui-icons-common": "^3.0.0",
@@ -27,10 +27,10 @@ to: package.json
     "recharts": "^2.0.0"
   },
   "devDependencies": {
-    "@astrojs/cloudflare": "^12.5.3",
     "@astrojs/react": "^4.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
     "@wix/cli": "^1.1.135",
     "@wix/sdk-types": "^1.0.0",
     "react": "^18.3.1",

--- a/custom-products-catalog/template/astro.config.mjs
+++ b/custom-products-catalog/template/astro.config.mjs
@@ -2,11 +2,11 @@
 import { defineConfig } from 'astro/config';
 import wix from '@wix/astro';
 import react from "@astrojs/react";
-import cloudflare from "@astrojs/cloudflare";
+import wixHostingAdapter from "@wix/astro-wix-hosting-adapter";
 
 export default defineConfig({
   output: "server",
-  adapter: cloudflare(),
+  adapter: wixHostingAdapter(),
   integrations: [wix(), react()],
   image: { domains: ["static.wixstatic.com"] },
   devToolbar: { enabled: false },

--- a/custom-products-catalog/template/package.json.ejs
+++ b/custom-products-catalog/template/package.json.ejs
@@ -18,7 +18,7 @@ to: package.json
   },
   "dependencies": {
     "@wix/dashboard": "^1.3.43",
-    "@wix/astro": "^2.13.0",
+    "@wix/astro": "^2.39.0",
     "@wix/design-system": "^1.111.0",
     "@wix/essentials": "^0.1.4",
     "@wix/patterns": "^1.3.0",
@@ -29,10 +29,10 @@ to: package.json
     "typescript": "^5.8.3"
   },
   "devDependencies": {
-    "@astrojs/cloudflare": "^12.5.3",
     "@astrojs/react": "^4.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
     "@wix/cli": "^1.1.135",
     "@wix/sdk-types": "^1.0.0",
     "react": "^18.3.1",

--- a/inventory-countdown/template/astro.config.mjs
+++ b/inventory-countdown/template/astro.config.mjs
@@ -2,11 +2,11 @@
 import { defineConfig } from 'astro/config';
 import wix from '@wix/astro';
 import react from "@astrojs/react";
-import cloudflare from "@astrojs/cloudflare";
+import wixHostingAdapter from "@wix/astro-wix-hosting-adapter";
 
 export default defineConfig({
   output: "server",
-  adapter: cloudflare(),
+  adapter: wixHostingAdapter(),
   integrations: [wix(), react()],
   image: { domains: ["static.wixstatic.com"] },
   devToolbar: { enabled: false },

--- a/inventory-countdown/template/package.json.ejs
+++ b/inventory-countdown/template/package.json.ejs
@@ -17,7 +17,7 @@ to: package.json
     "generate": "wix generate"
   },
   "dependencies": {
-    "@wix/astro": "^2.13.0",
+    "@wix/astro": "^2.39.0",
     "@wix/dashboard": "^1.3.21",
     "@wix/design-system": "^1.0.0",
     "@wix/editor": "^1.308.0",
@@ -29,10 +29,10 @@ to: package.json
     "typescript": "^5.8.3"
   },
   "devDependencies": {
-    "@astrojs/cloudflare": "^12.5.3",
     "@astrojs/react": "^4.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
     "@wix/cli": "^1.1.135",
     "@wix/sdk-types": "^1.0.0",
     "react": "^18.3.1",

--- a/mixpanel-analytics/template/astro.config.mjs
+++ b/mixpanel-analytics/template/astro.config.mjs
@@ -2,11 +2,11 @@
 import { defineConfig } from 'astro/config';
 import wix from '@wix/astro';
 import react from "@astrojs/react";
-import cloudflare from "@astrojs/cloudflare";
+import wixHostingAdapter from "@wix/astro-wix-hosting-adapter";
 
 export default defineConfig({
   output: "server",
-  adapter: cloudflare(),
+  adapter: wixHostingAdapter(),
   integrations: [wix(), react()],
   image: { domains: ["static.wixstatic.com"] },
   devToolbar: { enabled: false },

--- a/mixpanel-analytics/template/package.json.ejs
+++ b/mixpanel-analytics/template/package.json.ejs
@@ -18,7 +18,7 @@ to: package.json
   },
   "dependencies": {
     "@tanstack/react-query": "^4.36.1",
-    "@wix/astro": "^2.13.0",
+    "@wix/astro": "^2.39.0",
     "@wix/app-management": "^1.0.0",
     "@wix/design-system": "^1.111.0",
     "@wix/essentials": "^0.1.4",
@@ -29,10 +29,10 @@ to: package.json
     "typescript": "^5.8.3"
   },
   "devDependencies": {
-    "@astrojs/cloudflare": "^12.5.3",
     "@astrojs/react": "^4.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
     "@wix/cli": "^1.1.135",
     "@wix/sdk-types": "^1.0.0",
     "react": "^18.3.1",

--- a/shipping-rates/template/astro.config.mjs.ejs
+++ b/shipping-rates/template/astro.config.mjs.ejs
@@ -5,11 +5,11 @@ to: astro.config.mjs
 import { defineConfig } from 'astro/config';
 import wix from '@wix/astro';
 import react from "@astrojs/react";
-import cloudflare from "@astrojs/cloudflare";
+import wixHostingAdapter from "@wix/astro-wix-hosting-adapter";
 
 export default defineConfig({
   output: "server",
-  adapter: cloudflare(),
+  adapter: wixHostingAdapter(),
   integrations: [wix(), react()],
   image: { domains: ["static.wixstatic.com"] },
   devToolbar: { enabled: false },

--- a/shipping-rates/template/package.json.ejs
+++ b/shipping-rates/template/package.json.ejs
@@ -19,7 +19,7 @@ to: package.json
   "dependencies": {
     "@tanstack/react-query": "^4.36.1",
     "@wix/app-management": "^1.0.0",
-    "@wix/astro": "^2.13.0",
+    "@wix/astro": "^2.39.0",
     "@wix/dashboard": "^1.3.21",
     "@wix/design-system": "^1.111.0",
     "@wix/ecom": "^1.0.668",
@@ -30,10 +30,10 @@ to: package.json
     "typescript": "^5.8.3"
   },
   "devDependencies": {
-    "@astrojs/cloudflare": "^12.5.3",
     "@astrojs/react": "^4.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
     "@wix/cli": "^1.1.135",
     "@wix/sdk-types": "^1.0.0",
     "react": "^18.3.1",

--- a/site-popup/template/astro.config.mjs
+++ b/site-popup/template/astro.config.mjs
@@ -2,11 +2,11 @@
 import { defineConfig } from 'astro/config';
 import wix from '@wix/astro';
 import react from "@astrojs/react";
-import cloudflare from "@astrojs/cloudflare";
+import wixHostingAdapter from "@wix/astro-wix-hosting-adapter";
 
 export default defineConfig({
   output: "server",
-  adapter: cloudflare(),
+  adapter: wixHostingAdapter(),
   integrations: [wix(), react()],
   image: { domains: ["static.wixstatic.com"] },
   devToolbar: { enabled: false },

--- a/site-popup/template/package.json.ejs
+++ b/site-popup/template/package.json.ejs
@@ -18,7 +18,7 @@ to: package.json
   },
   "dependencies": {
     "@tanstack/react-query": "^4.36.1",
-    "@wix/astro": "^2.13.0",
+    "@wix/astro": "^2.39.0",
     "@wix/app-management": "^1.0.0",
     "@wix/dashboard": "^1.3.21",
     "@wix/design-system": "^1.111.0",
@@ -30,10 +30,10 @@ to: package.json
     "typescript": "^5.8.3"
   },
   "devDependencies": {
-    "@astrojs/cloudflare": "^12.5.3",
     "@astrojs/react": "^4.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
     "@wix/cli": "^1.1.135",
     "@wix/sdk-types": "^1.0.0",
     "autoprefixer": "^10.4.17",


### PR DESCRIPTION
Replaces the `@astrojs/cloudflare` adapter with [`@wix/astro-wix-hosting-adapter@^2.0.0`](https://github.com/wix-private/headless-integrations/tree/master/packages/astro-wix-hosting-adapter) — which  is the supported hosting adapter for Wix CLI apps — across all 7 templates.
